### PR TITLE
Add live preview experience to template details page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function DashboardPage() {
   const purchasedTemplates = templates.filter((template) =>
-    purchasedTemplateIds.includes(template.slug),
+    purchasedTemplateIds.includes(template.id),
   );
 
   return (

--- a/src/components/template-card.tsx
+++ b/src/components/template-card.tsx
@@ -26,12 +26,15 @@ export function TemplateCard({ template }: { template: Template }) {
           </p>
         </div>
         <div className="mt-auto flex items-center justify-between pt-4 text-sm font-medium">
-          <Link href={`/templates/${template.slug}`} className="text-neutral-900 transition hover:text-neutral-600">
+          <Link href={`/templates/${template.id}`} className="text-neutral-900 transition hover:text-neutral-600">
             View details
           </Link>
-          <span className="rounded-full bg-neutral-900 px-4 py-2 text-white transition hover:bg-neutral-800">
+          <Link
+            href={`/templates/${template.id}?preview=true`}
+            className="rounded-full bg-neutral-900 px-4 py-2 text-white transition hover:bg-neutral-800"
+          >
             Preview
-          </span>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/template-live-preview.tsx
+++ b/src/components/template-live-preview.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export function TemplateLivePreview({
+  url,
+  name,
+  defaultOpen = false,
+}: {
+  url: string;
+  name: string;
+  defaultOpen?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="space-y-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800"
+        >
+          {isOpen ? "Hide live preview" : "Open live preview"}
+        </button>
+        <Link
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center rounded-full border border-neutral-200 px-5 py-2 text-sm font-semibold text-neutral-700 transition hover:border-neutral-300 hover:text-neutral-900"
+        >
+          Open in new tab
+        </Link>
+      </div>
+      {isOpen && (
+        <div
+          className="overflow-hidden rounded-2xl border border-neutral-200"
+          style={{ aspectRatio: "16 / 10" }}
+        >
+          <iframe
+            src={url}
+            title={`${name} live preview`}
+            className="h-full w-full"
+            loading="lazy"
+            allow="clipboard-write; fullscreen"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -168,6 +168,6 @@ export const categories = [
 
 export type CategoryFilter = (typeof categories)[number];
 
-export function getTemplateBySlug(slug: string) {
-  return templates.find((template) => template.slug === slug);
+export function getTemplateById(id: string) {
+  return templates.find((template) => template.id === id);
 }


### PR DESCRIPTION
## Summary
- update the template details route to use /templates/[id] with refreshed metadata and layout copy
- link gallery actions to the id-based detail page and support preview deep links
- add an interactive live preview component with iframe/new tab options for template demos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d700e862188326b86ce9e9550aba88