### PR TITLE
Add credentials-based authentication

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { connectDB } from "@/lib/mongodb";
+import { User } from "@/models/user";
+import { hashPassword } from "@/lib/auth-utils";
+import { z } from "zod";
+
+const registerSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters long"),
+  email: z.string().email("Please provide a valid email address"),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters long")
+    .regex(/^(?=.*[A-Za-z])(?=.*\d).+$/, "Password must contain at least one letter and one number"),
+});
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const parsed = registerSchema.safeParse(body);
+
+    if (!parsed.success) {
+      const errorMessage = parsed.error.issues[0]?.message ?? "Invalid request";
+      return NextResponse.json({ message: errorMessage }, { status: 400 });
+    }
+
+    await connectDB();
+
+    const existingUser = await User.findOne({ email: parsed.data.email }).exec();
+    if (existingUser) {
+      return NextResponse.json(
+        { message: "An account with that email already exists" },
+        { status: 409 },
+      );
+    }
+
+    const hashedPassword = hashPassword(parsed.data.password);
+    await User.create({
+      name: parsed.data.name,
+      email: parsed.data.email,
+      password: hashedPassword,
+    });
+
+    return NextResponse.json({ message: "Account created successfully" }, { status: 201 });
+  } catch (error) {
+    console.error("Error creating user", error);
+    return NextResponse.json({ message: "Something went wrong" }, { status: 500 });
+  }
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { LoginForm } from "@/components/auth/login-form";
 
 export const metadata: Metadata = {
   title: "Log in",
@@ -15,32 +16,7 @@ export default function LoginPage() {
             Log in to access your purchased templates and download history.
           </p>
         </div>
-        <form className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
-          <label className="text-sm font-medium text-neutral-700" htmlFor="email">
-            Email
-          </label>
-          <input
-            id="email"
-            type="email"
-            placeholder="you@studio.com"
-            className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
-          />
-          <label className="text-sm font-medium text-neutral-700" htmlFor="password">
-            Password
-          </label>
-          <input
-            id="password"
-            type="password"
-            placeholder="••••••••"
-            className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
-          />
-          <button
-            type="submit"
-            className="mt-4 rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800"
-          >
-            Log in
-          </button>
-        </form>
+        <LoginForm />
         <p className="text-center text-sm text-neutral-600">
           Need an account?{" "}
           <Link href="/auth/register" className="font-medium text-neutral-900 hover:underline">

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { RegisterForm } from "@/components/auth/register-form";
 
 export const metadata: Metadata = {
   title: "Create account",
@@ -15,41 +16,7 @@ export default function RegisterPage() {
             Save your purchased templates, download files anytime, and access deployment guides.
           </p>
         </div>
-        <form className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
-          <label className="text-sm font-medium text-neutral-700" htmlFor="name">
-            Full name
-          </label>
-          <input
-            id="name"
-            type="text"
-            placeholder="Jordan Smith"
-            className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
-          />
-          <label className="text-sm font-medium text-neutral-700" htmlFor="email">
-            Email
-          </label>
-          <input
-            id="email"
-            type="email"
-            placeholder="you@studio.com"
-            className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
-          />
-          <label className="text-sm font-medium text-neutral-700" htmlFor="password">
-            Password
-          </label>
-          <input
-            id="password"
-            type="password"
-            placeholder="Create a secure password"
-            className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
-          />
-          <button
-            type="submit"
-            className="mt-4 rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800"
-          >
-            Create account
-          </button>
-        </form>
+        <RegisterForm />
         <p className="text-center text-sm text-neutral-600">
           Already have an account?{" "}
           <Link href="/auth/login" className="font-medium text-neutral-900 hover:underline">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 import { templates } from "@/lib/templates";
+import { authOptions } from "@/lib/auth";
 
 const purchasedTemplateIds = ["dental-studio", "modern-consultancy"];
 
@@ -9,7 +12,13 @@ export const metadata: Metadata = {
   description: "Access your purchased templates, download project files, and grab deployment resources.",
 };
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect(`/auth/login?callbackUrl=/dashboard`);
+  }
+
   const purchasedTemplates = templates.filter((template) =>
     purchasedTemplateIds.includes(template.id),
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
+import { AuthProvider } from "@/components/providers/session-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -34,13 +35,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} bg-neutral-50 text-neutral-900 antialiased`}>
-        <div className="flex min-h-screen flex-col">
-          <SiteHeader />
-          <main className="flex-1 bg-white">
-            {children}
-          </main>
-          <SiteFooter />
-        </div>
+        <AuthProvider>
+          <div className="flex min-h-screen flex-col">
+            <SiteHeader />
+            <main className="flex-1 bg-white">{children}</main>
+            <SiteFooter />
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard";
+  const registered = searchParams.get("registered");
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(
+    registered ? "Account created successfully. You can log in now." : null,
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const email = String(formData.get("email") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+
+    if (!email || !password) {
+      setError("Please provide both an email and password");
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+        callbackUrl,
+      });
+
+      if (!result) {
+        setError("Unexpected response from the server");
+        return;
+      }
+
+      if (result.error) {
+        setError("Invalid email or password. Please try again.");
+        return;
+      }
+
+      setSuccess("Logged in successfully. Redirecting...");
+      router.push(result.url ?? callbackUrl);
+      router.refresh();
+    } catch (err) {
+      console.error("Error signing in", err);
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm"
+    >
+      <label className="text-sm font-medium text-neutral-700" htmlFor="email">
+        Email
+      </label>
+      <input
+        id="email"
+        name="email"
+        type="email"
+        placeholder="you@studio.com"
+        className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
+        required
+        autoComplete="email"
+      />
+      <label className="text-sm font-medium text-neutral-700" htmlFor="password">
+        Password
+      </label>
+      <input
+        id="password"
+        name="password"
+        type="password"
+        placeholder="••••••••"
+        className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
+        required
+        autoComplete="current-password"
+      />
+      {error && <p className="text-sm font-medium text-red-600">{error}</p>}
+      {success && <p className="text-sm font-medium text-emerald-600">{success}</p>}
+      <button
+        type="submit"
+        className="mt-2 rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-70"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Logging in..." : "Log in"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const name = String(formData.get("name") ?? "").trim();
+    const email = String(formData.get("email") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+
+    if (!name || !email || !password) {
+      setError("Please complete all fields");
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name, email, password }),
+      });
+
+      const data = (await response.json()) as { message?: string };
+
+      if (!response.ok) {
+        setError(data.message ?? "Unable to create your account");
+        return;
+      }
+
+      setSuccess(data.message ?? "Account created successfully");
+      event.currentTarget.reset();
+
+      setTimeout(() => {
+        router.push("/auth/login?registered=1");
+      }, 1200);
+    } catch (err) {
+      console.error("Error creating account", err);
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm"
+    >
+      <label className="text-sm font-medium text-neutral-700" htmlFor="name">
+        Full name
+      </label>
+      <input
+        id="name"
+        name="name"
+        type="text"
+        placeholder="Jordan Smith"
+        className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
+        required
+        autoComplete="name"
+      />
+      <label className="text-sm font-medium text-neutral-700" htmlFor="email">
+        Email
+      </label>
+      <input
+        id="email"
+        name="email"
+        type="email"
+        placeholder="you@studio.com"
+        className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
+        required
+        autoComplete="email"
+      />
+      <label className="text-sm font-medium text-neutral-700" htmlFor="password">
+        Password
+      </label>
+      <input
+        id="password"
+        name="password"
+        type="password"
+        placeholder="Create a secure password"
+        className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-sm shadow-sm focus:border-neutral-900 focus:outline-none"
+        required
+        autoComplete="new-password"
+        minLength={8}
+      />
+      <p className="text-xs text-neutral-500">
+        Passwords must be at least 8 characters and include at least one letter and one number.
+      </p>
+      {error && <p className="text-sm font-medium text-red-600">{error}</p>}
+      {success && <p className="text-sm font-medium text-emerald-600">{success}</p>}
+      <button
+        type="submit"
+        className="mt-2 rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-70"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Creating account..." : "Create account"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/providers/session-provider.tsx
+++ b/src/components/providers/session-provider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { signOut, useSession } from "next-auth/react";
 
 const links = [
   { href: "/", label: "Home" },
@@ -12,6 +13,15 @@ const links = [
 
 export function SiteHeader() {
   const pathname = usePathname();
+  const router = useRouter();
+  const { data: session, status } = useSession();
+
+  async function handleSignOut() {
+    await signOut({ callbackUrl: "/" });
+    router.refresh();
+  }
+
+  const isAuthenticated = status === "authenticated" && session?.user;
 
   return (
     <header className="sticky top-0 z-50 border-b border-neutral-200 bg-white/80 backdrop-blur">
@@ -26,9 +36,7 @@ export function SiteHeader() {
               <Link
                 key={link.href}
                 href={link.href}
-                className={`transition-colors hover:text-neutral-900 ${
-                  isActive ? "text-neutral-900" : ""
-                }`}
+                className={`transition-colors hover:text-neutral-900 ${isActive ? "text-neutral-900" : ""}`}
               >
                 {link.label}
               </Link>
@@ -36,18 +44,43 @@ export function SiteHeader() {
           })}
         </nav>
         <div className="flex items-center gap-3 text-sm font-medium">
-          <Link
-            href="/auth/login"
-            className="rounded-full border border-neutral-200 px-4 py-2 transition hover:border-neutral-300 hover:bg-neutral-50"
-          >
-            Log in
-          </Link>
-          <Link
-            href="/auth/register"
-            className="rounded-full bg-neutral-900 px-4 py-2 text-white shadow-md transition hover:bg-neutral-800"
-          >
-            Get started
-          </Link>
+          {status === "loading" ? (
+            <span className="text-neutral-500">Loading...</span>
+          ) : isAuthenticated ? (
+            <>
+              <span className="hidden text-neutral-600 md:inline">
+                {session.user?.name ?? session.user?.email}
+              </span>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="rounded-full border border-neutral-200 px-4 py-2 transition hover:border-neutral-300 hover:bg-neutral-50"
+              >
+                Log out
+              </button>
+              <Link
+                href="/dashboard"
+                className="rounded-full bg-neutral-900 px-4 py-2 text-white shadow-md transition hover:bg-neutral-800"
+              >
+                Dashboard
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link
+                href="/auth/login"
+                className="rounded-full border border-neutral-200 px-4 py-2 transition hover:border-neutral-300 hover:bg-neutral-50"
+              >
+                Log in
+              </Link>
+              <Link
+                href="/auth/register"
+                className="rounded-full bg-neutral-900 px-4 py-2 text-white shadow-md transition hover:bg-neutral-800"
+              >
+                Get started
+              </Link>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,0 +1,24 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+const KEY_LENGTH = 64;
+
+export function hashPassword(password: string) {
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+export function verifyPassword(password: string, storedHash: string) {
+  const [salt, key] = storedHash.split(":");
+  if (!salt || !key) {
+    return false;
+  }
+  const hashedBuffer = Buffer.from(key, "hex");
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+
+  if (hashedBuffer.length !== derivedKey.length) {
+    return false;
+  }
+
+  return timingSafeEqual(hashedBuffer, derivedKey);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,71 @@
+import { connectDB } from "@/lib/mongodb";
+import { verifyPassword } from "@/lib/auth-utils";
+import { User } from "@/models/user";
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { z } from "zod";
+
+const credentialsSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const parsed = credentialsSchema.safeParse(credentials);
+        if (!parsed.success) {
+          return null;
+        }
+
+        await connectDB();
+        const user = await User.findOne({ email: parsed.data.email }).exec();
+        if (!user) {
+          return null;
+        }
+
+        const isValidPassword = verifyPassword(parsed.data.password, user.password);
+        if (!isValidPassword) {
+          return null;
+        }
+
+        return {
+          id: user._id.toString(),
+          email: user.email,
+          name: user.name,
+        };
+      },
+    }),
+  ],
+  pages: {
+    signIn: "/auth/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.sub = (user as { id?: string }).id ?? token.sub;
+        token.name = user.name;
+        token.email = user.email;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = (token.sub as string) ?? "";
+        session.user.email = token.email;
+        session.user.name = token.name;
+      }
+      return session;
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,22 @@
+import { Schema, model, models, type Model, type Document } from "mongoose";
+
+export interface IUser extends Document {
+  name: string;
+  email: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const UserSchema = new Schema<IUser, Model<IUser>>(
+  {
+    name: { type: String, required: true, trim: true },
+    email: { type: String, required: true, unique: true, lowercase: true, trim: true },
+    password: { type: String, required: true },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const User = (models.User as Model<IUser>) || model<IUser>("User", UserSchema);

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+    };
+  }
+
+  interface User {
+    id: string;
+  }
+}


### PR DESCRIPTION
## Summary
- add a credentials-based NextAuth configuration backed by a Mongo user model and scrypt password hashing
- expose registration and sign-in flows with interactive client forms and API routes
- wrap the app in the session provider, protect the dashboard, and surface auth status in the site header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7051542b4832692fbf2c10466ddc6