### PR TITLE
Add Stripe checkout flow with purchase tracking

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import Stripe from "stripe";
+
+import { authOptions } from "@/lib/auth";
+import { getTemplateById } from "@/lib/templates";
+import { connectDB } from "@/lib/mongodb";
+import { Purchase } from "@/models/purchase";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+if (!stripeSecretKey) {
+  throw new Error("Missing STRIPE_SECRET_KEY environment variable.");
+}
+
+if (!appUrl) {
+  throw new Error("Missing NEXT_PUBLIC_APP_URL environment variable.");
+}
+
+const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2024-11-20",
+});
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id || !session.user.email) {
+    return NextResponse.json({ error: "You must be signed in to checkout." }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { templateId?: string } | null;
+
+  if (!body?.templateId) {
+    return NextResponse.json({ error: "Template ID is required." }, { status: 400 });
+  }
+
+  const template = getTemplateById(body.templateId);
+
+  if (!template) {
+    return NextResponse.json({ error: "Template not found." }, { status: 404 });
+  }
+
+  await connectDB();
+
+  const existingPurchase = await Purchase.findOne({
+    userId: session.user.id,
+    templateId: template.id,
+    status: "completed",
+  }).exec();
+
+  if (existingPurchase) {
+    return NextResponse.json(
+      { error: "You already own this template." },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "payment",
+      customer_email: session.user.email ?? undefined,
+      metadata: {
+        userId: session.user.id,
+        templateId: template.id,
+      },
+      success_url: `${appUrl}/dashboard?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${appUrl}/templates/${template.id}?checkout=cancelled`,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: "usd",
+            unit_amount: template.price * 100,
+            product_data: {
+              name: template.name,
+              description: template.description,
+            },
+          },
+        },
+      ],
+    });
+
+    await Purchase.findOneAndUpdate(
+      { stripeSessionId: checkoutSession.id },
+      {
+        userId: session.user.id,
+        templateId: template.id,
+        status: "pending",
+        purchaseDate: new Date(),
+        stripePaymentIntentId:
+          typeof checkoutSession.payment_intent === "string"
+            ? checkoutSession.payment_intent
+            : checkoutSession.payment_intent?.id,
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+
+    return NextResponse.json({ url: checkoutSession.url });
+  } catch (error) {
+    console.error("Failed to create Stripe checkout session", error);
+    return NextResponse.json(
+      { error: "Unable to create checkout session." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+import { connectDB } from "@/lib/mongodb";
+import { Purchase } from "@/models/purchase";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!stripeSecretKey) {
+  throw new Error("Missing STRIPE_SECRET_KEY environment variable.");
+}
+
+if (!webhookSecret) {
+  throw new Error("Missing STRIPE_WEBHOOK_SECRET environment variable.");
+}
+
+const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2024-11-20",
+});
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const signature = request.headers.get("stripe-signature");
+
+  if (!signature) {
+    return new NextResponse("Missing Stripe signature header.", { status: 400 });
+  }
+
+  const body = await request.arrayBuffer();
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(Buffer.from(body), signature, webhookSecret);
+  } catch (error) {
+    console.error("Stripe webhook signature verification failed", error);
+    return new NextResponse("Webhook signature verification failed.", { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const templateId = session.metadata?.templateId;
+        const userId = session.metadata?.userId;
+
+        if (!templateId || !userId) {
+          break;
+        }
+
+        await connectDB();
+
+        await Purchase.findOneAndUpdate(
+          { stripeSessionId: session.id },
+          {
+            userId,
+            templateId,
+            status: "completed",
+            purchaseDate: new Date(),
+            stripePaymentIntentId:
+              typeof session.payment_intent === "string"
+                ? session.payment_intent
+                : session.payment_intent?.id,
+          },
+          { upsert: true, new: true, setDefaultsOnInsert: true },
+        );
+        break;
+      }
+      case "checkout.session.async_payment_failed":
+      case "checkout.session.expired": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        await connectDB();
+        await Purchase.findOneAndUpdate(
+          { stripeSessionId: session.id },
+          { status: "failed", purchaseDate: new Date() },
+        ).exec();
+        break;
+      }
+      default: {
+        // Unsupported event type; acknowledge without action
+        break;
+      }
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error("Error handling Stripe webhook", error);
+    return new NextResponse("Webhook handler failed.", { status: 500 });
+  }
+}

--- a/src/app/templates/[id]/page.tsx
+++ b/src/app/templates/[id]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTemplateById, templates } from "@/lib/templates";
 import { TemplateLivePreview } from "@/components/template-live-preview";
+import { CheckoutButton } from "@/components/checkout-button";
 
 export function generateStaticParams() {
   return templates.map((template) => ({ id: template.id }));
@@ -67,12 +68,7 @@ export default async function TemplateDetailPage({ params, searchParams }: Templ
               </div>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row">
-              <Link
-                href="/checkout"
-                className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-neutral-800"
-              >
-                Buy now
-              </Link>
+              <CheckoutButton templateId={template.id} templateName={template.name} />
               {template.demoUrl && (
                 <Link
                   href={template.demoUrl}

--- a/src/components/checkout-button.tsx
+++ b/src/components/checkout-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+type CheckoutButtonProps = {
+  templateId: string;
+  templateName: string;
+  className?: string;
+};
+
+export function CheckoutButton({ templateId, templateName, className }: CheckoutButtonProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCheckout = async () => {
+    try {
+      setIsLoading(true);
+      const response = await fetch("/api/checkout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ templateId }),
+      });
+
+      if (response.status === 401) {
+        window.location.href = "/auth/login";
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const message = (errorData as { error?: string }).error ?? "Unable to start checkout. Please try again.";
+        throw new Error(message);
+      }
+
+      const data = (await response.json()) as { url?: string };
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        throw new Error("Checkout session missing redirect URL.");
+      }
+    } catch (error) {
+      console.error(`Failed to start checkout for ${templateName}:`, error);
+      window.alert("We couldn't start the checkout. Please try again in a moment.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCheckout}
+      disabled={isLoading}
+      className={`inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-70 ${className ?? ""}`}
+    >
+      {isLoading ? "Redirecting…" : "Buy now"}
+    </button>
+  );
+}

--- a/src/models/purchase.ts
+++ b/src/models/purchase.ts
@@ -1,0 +1,30 @@
+import { Schema, model, models, type Document, type Model } from "mongoose";
+
+export type PurchaseStatus = "pending" | "completed" | "failed";
+
+export interface IPurchase extends Document {
+  userId: string;
+  templateId: string;
+  purchaseDate: Date;
+  status: PurchaseStatus;
+  stripeSessionId: string;
+  stripePaymentIntentId?: string;
+}
+
+const PurchaseSchema = new Schema<IPurchase, Model<IPurchase>>(
+  {
+    userId: { type: String, required: true, index: true },
+    templateId: { type: String, required: true, index: true },
+    purchaseDate: { type: Date, default: () => new Date(), required: true },
+    status: { type: String, enum: ["pending", "completed", "failed"], default: "pending" },
+    stripeSessionId: { type: String, required: true, unique: true },
+    stripePaymentIntentId: { type: String },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+PurchaseSchema.index({ userId: 1, templateId: 1 }, { unique: false });
+
+export const Purchase = (models.Purchase as Model<IPurchase>) || model<IPurchase>("Purchase", PurchaseSchema);


### PR DESCRIPTION
## Summary
- add a Stripe-powered checkout session endpoint that validates template purchases and stores pending records
- handle Stripe webhook events to mark purchases complete or failed in MongoDB
- expose a reusable checkout button on template detail pages backed by the new purchase model

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7140ba2a48326a916d1d96adabfbe