### PR TITLE
Add purchased templates section to dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,32 @@ import { authOptions } from "@/lib/auth";
 
 const purchasedTemplateIds = ["dental-studio", "modern-consultancy"];
 
+const purchaseMetadata: Record<
+  (typeof purchasedTemplateIds)[number],
+  {
+    orderNumber: string;
+    purchaseDate: string;
+    licenseType: string;
+    downloadUrl: string;
+    licenseUrl: string;
+  }
+> = {
+  "dental-studio": {
+    orderNumber: "ORD-2048",
+    purchaseDate: "March 4, 2024",
+    licenseType: "Commercial License",
+    downloadUrl: "#",
+    licenseUrl: "#",
+  },
+  "modern-consultancy": {
+    orderNumber: "ORD-1994",
+    purchaseDate: "February 22, 2024",
+    licenseType: "Agency License",
+    downloadUrl: "#",
+    licenseUrl: "#",
+  },
+};
+
 export const metadata: Metadata = {
   title: "Dashboard",
   description: "Access your purchased templates, download project files, and grab deployment resources.",
@@ -33,41 +59,63 @@ export default async function DashboardPage() {
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          {purchasedTemplates.map((template) => (
-            <div key={template.id} className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">
-                    {template.category}
-                  </p>
-                  <h2 className="text-xl font-semibold text-neutral-900">{template.name}</h2>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-neutral-900">Purchased templates</h2>
+            <p className="text-xs uppercase tracking-[0.3em] text-neutral-400">Sample data</p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            {purchasedTemplates.map((template) => (
+              <div
+                key={template.id}
+                className="flex flex-col gap-4 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">
+                      {template.category}
+                    </p>
+                    <h3 className="text-xl font-semibold text-neutral-900">{template.name}</h3>
+                  </div>
+                  <span className="text-sm font-medium text-neutral-500">${template.price}</span>
                 </div>
-                <span className="text-sm font-medium text-neutral-500">${template.price}</span>
+                <p className="text-sm text-neutral-600">{template.description}</p>
+                <dl className="grid gap-2 rounded-2xl bg-neutral-50 p-4 text-sm text-neutral-600">
+                  <div className="flex items-center justify-between">
+                    <dt className="font-medium text-neutral-500">Order number</dt>
+                    <dd className="font-semibold text-neutral-800">
+                      {purchaseMetadata[template.id as keyof typeof purchaseMetadata]?.orderNumber ?? "—"}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="font-medium text-neutral-500">Purchase date</dt>
+                    <dd>{purchaseMetadata[template.id as keyof typeof purchaseMetadata]?.purchaseDate ?? "—"}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="font-medium text-neutral-500">License</dt>
+                    <dd>{purchaseMetadata[template.id as keyof typeof purchaseMetadata]?.licenseType ?? "—"}</dd>
+                  </div>
+                </dl>
+                <div className="flex flex-wrap gap-3 text-sm font-medium">
+                  <Link
+                    href={purchaseMetadata[template.id as keyof typeof purchaseMetadata]?.downloadUrl ?? "#"}
+                    className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-4 py-2 text-white transition hover:bg-neutral-800"
+                  >
+                    Download ZIP
+                  </Link>
+                  <Link
+                    href={purchaseMetadata[template.id as keyof typeof purchaseMetadata]?.licenseUrl ?? "#"}
+                    className="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-neutral-700 transition hover:border-neutral-300 hover:text-neutral-900"
+                  >
+                    View license &amp; receipt
+                  </Link>
+                  <span className="inline-flex items-center justify-center rounded-full border border-dashed border-neutral-300 px-4 py-2 text-neutral-400">
+                    One-click deploy (soon)
+                  </span>
+                </div>
               </div>
-              <p className="text-sm text-neutral-600">{template.description}</p>
-              <div className="flex flex-wrap gap-3 text-sm font-medium">
-                <Link
-                  href="#"
-                  className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-4 py-2 text-white transition hover:bg-neutral-800"
-                >
-                  Download ZIP
-                </Link>
-                <Link
-                  href="#"
-                  className="inline-flex items-center justify-center rounded-full border border-neutral-200 px-4 py-2 text-neutral-700 transition hover:border-neutral-300 hover:text-neutral-900"
-                >
-                  Deployment guide
-                </Link>
-                <Link
-                  href="#"
-                  className="inline-flex items-center justify-center rounded-full border border-dashed border-neutral-300 px-4 py-2 text-neutral-500 transition hover:border-neutral-400 hover:text-neutral-700"
-                >
-                  Customize branding
-                </Link>
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
 
         <div className="rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">


### PR DESCRIPTION
## Summary
- add purchase metadata for sample templates and surface it in the dashboard cards
- reorganize the dashboard layout with a "Purchased templates" section and updated actions for downloads, license info, and future deploy links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7174fa574832683d4a0ad34557694