### PR TITLE
feat: scaffold template exports and generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+exports/
 
 # misc
 .DS_Store

--- a/prosite-app/templates/saas-starter/app/globals.css
+++ b/prosite-app/templates/saas-starter/app/globals.css
@@ -1,0 +1,13 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/prosite-app/templates/saas-starter/app/layout.tsx
+++ b/prosite-app/templates/saas-starter/app/layout.tsx
@@ -1,0 +1,21 @@
+import "./globals.css";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "{{siteName}}",
+  description: "{{tagline}}",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-[{{primaryColor}}] text-white">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/prosite-app/templates/saas-starter/app/page.tsx
+++ b/prosite-app/templates/saas-starter/app/page.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image";
+
+export default function Page() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-16 px-6 py-24">
+      <header className="flex flex-col items-center gap-6 text-center">
+        <Image
+          src="{{logoUrl}}"
+          alt="{{siteName}} logo"
+          width={96}
+          height={96}
+          className="h-24 w-24 rounded-full bg-white/10 object-contain"
+        />
+        <h1 className="text-4xl font-bold tracking-tight text-white sm:text-6xl">
+          {{siteName}}
+        </h1>
+        <p className="max-w-2xl text-lg text-white/80">{{tagline}}</p>
+      </header>
+
+      <section className="grid gap-10 rounded-3xl bg-white/5 p-10 text-left text-white shadow-xl backdrop-blur">
+        <div>
+          <h2 className="text-2xl font-semibold">Launch faster with opinionated defaults</h2>
+          <p className="mt-4 text-white/80">
+            {{siteName}} comes ready to ship with a polished SaaS marketing site. Swap
+            the placeholder copy, plug in your product screenshots, and ship in
+            a weekend.
+          </p>
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold">Why founders love {{siteName}}</h3>
+          <ul className="mt-4 space-y-3 text-white/80">
+            <li>✅ Conversion-first hero section</li>
+            <li>✅ Pricing table with highlight cards</li>
+            <li>✅ Blog-ready content structure</li>
+            <li>✅ Reusable call-to-action components</li>
+          </ul>
+        </div>
+      </section>
+
+      <footer className="flex flex-col items-center justify-between gap-4 rounded-3xl bg-white/5 p-6 text-sm text-white/70 sm:flex-row">
+        <span>Built for modern SaaS teams.</span>
+        <span>© {new Date().getFullYear()} {{siteName}}.</span>
+      </footer>
+    </main>
+  );
+}

--- a/prosite-app/templates/saas-starter/components/CallToAction.tsx
+++ b/prosite-app/templates/saas-starter/components/CallToAction.tsx
@@ -1,0 +1,25 @@
+export function CallToAction() {
+  return (
+    <section className="rounded-3xl bg-white/10 p-10 text-center text-white shadow-lg">
+      <h2 className="text-3xl font-semibold">Ready to grow {{siteName}}?</h2>
+      <p className="mt-4 text-white/80">
+        Keep your brand consistent with the {{primaryColor}} color system and launch a
+        marketing site that matches your product experience.
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+        <a
+          href="/signup"
+          className="rounded-full bg-white px-6 py-3 text-base font-semibold text-[{{primaryColor}}] shadow-lg"
+        >
+          Start your trial
+        </a>
+        <a
+          href="/contact"
+          className="rounded-full border border-white/60 px-6 py-3 text-base font-semibold text-white"
+        >
+          Book a demo
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/prosite-app/templates/saas-starter/lib/marketingHighlights.ts
+++ b/prosite-app/templates/saas-starter/lib/marketingHighlights.ts
@@ -1,0 +1,17 @@
+export const highlights = [
+  {
+    title: "Opinionated layout",
+    description:
+      "{{siteName}} ships with a conversion-tested information architecture and polished UI patterns.",
+  },
+  {
+    title: "Brand-ready colors",
+    description:
+      "Update the Tailwind config with {{primaryColor}} to keep your marketing site on-brand in minutes.",
+  },
+  {
+    title: "Story-driven copy",
+    description:
+      "Lean on the {{tagline}} messaging framework to stay consistent across every page.",
+  },
+];

--- a/prosite-app/templates/saas-starter/package.json
+++ b/prosite-app/templates/saas-starter/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "saas-starter-{{siteName}}",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/src/lib/generateSite.ts
+++ b/src/lib/generateSite.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export type SiteConfig = {
+  siteName: string;
+  primaryColor: string;
+  tagline: string;
+  logoUrl: string;
+  [key: string]: string;
+};
+
+export type GenerateSiteOptions = {
+  templateId: string;
+  userConfig: SiteConfig;
+  userId: string;
+};
+
+const TEMPLATE_ROOT = path.join(process.cwd(), "prosite-app", "templates");
+const EXPORT_ROOT = path.join(process.cwd(), "exports");
+
+export async function generateSite(
+  templateId: string,
+  userConfig: SiteConfig,
+  userId: string
+): Promise<string> {
+  if (!templateId) {
+    throw new Error("templateId is required");
+  }
+
+  if (!userId) {
+    throw new Error("userId is required");
+  }
+
+  const templatePath = path.join(TEMPLATE_ROOT, templateId);
+  const templateExists = await exists(templatePath);
+
+  if (!templateExists) {
+    throw new Error(`Template with id "${templateId}" was not found at ${templatePath}`);
+  }
+
+  await fs.mkdir(EXPORT_ROOT, { recursive: true });
+
+  const exportFolderName = `${userId}-${templateId}`;
+  const exportPath = path.join(EXPORT_ROOT, exportFolderName);
+
+  await fs.rm(exportPath, { recursive: true, force: true });
+  await fs.mkdir(exportPath, { recursive: true });
+
+  await fs.cp(templatePath, exportPath, { recursive: true });
+
+  await replacePlaceholders(exportPath, userConfig);
+
+  return exportPath;
+}
+
+export default generateSite;
+
+async function replacePlaceholders(directory: string, replacements: Record<string, string>) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await replacePlaceholders(entryPath, replacements);
+        return;
+      }
+
+      if (!entry.isFile()) {
+        return;
+      }
+
+      const buffer = await fs.readFile(entryPath);
+      const original = buffer.toString("utf8");
+
+      let updated = original;
+      for (const [key, value] of Object.entries(replacements)) {
+        const token = `{{${key}}}`;
+        updated = updated.split(token).join(value ?? "");
+      }
+
+      if (updated !== original) {
+        await fs.writeFile(entryPath, updated, "utf8");
+      }
+    })
+  );
+}
+
+async function exists(targetPath: string) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `prosite-app/templates` workspace with the first `saas-starter` Next.js template wired with customization placeholders
- implement `generateSite` helper to copy a template, inject user configuration values, and return the export path
- ignore the generated `exports/` directory to keep artifacts out of version control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f5c01f008326bff878a61d374847